### PR TITLE
Last Second Fixes

### DIFF
--- a/mazebuilder.py
+++ b/mazebuilder.py
@@ -161,7 +161,7 @@ def main():
                maze.HK(mz, args.s)
          else:
             start = time_ns()
-            mz = maze.parallelize(args.algo, args.length, args.width, args.s, args.num_cores)
+            mz = maze.parallelize(args.algo, len, wid, args.s, args.num_cores)
 
          
          #calculate time for csv later
@@ -183,7 +183,7 @@ def main():
          
          if args.csv: 
             if run == 0 and trial == 0:
-               filename = str(args.algo).title() + '-' + strftime("%d-%H:%M:%S")
+               filename = args.csv
                csv = create_file(filename, extension='.csv', options='w+')
                csv.write('Seed,Length,Width,Time(ns),Passed Verification\n')
             csv.write(str(str(args.s) + ',' + str(len) + ',' + str(wid) + ',' + str(runtime) + ',' + str(check_connections(mz, args.s)) + '\n'))

--- a/src/include/HK.hpp
+++ b/src/include/HK.hpp
@@ -7,7 +7,7 @@
 template <CanMaze Mazeable = std::unique_ptr<Cell[]>>
 class HK
 {
-    Maze<Mazeable> &mz;
+    Maze<Mazeable> mz;
     std::minstd_rand r;
 
 public: 
@@ -36,6 +36,11 @@ public:
             mz.openStart();
             mz.openEnd();
         }
+    }
+
+    Maze<Mazeable> release () &&
+    {
+        return std::move(mz);
     }
 
     //output stream operator. Prints the underlying maze
@@ -96,6 +101,8 @@ private:
         }
         return mz.size();
     }
+
+
 };
 
 template <CanMaze Mazeable>

--- a/src/include/Maze.hpp
+++ b/src/include/Maze.hpp
@@ -69,10 +69,13 @@ public:
     //Equality op - Compares fields from smallest to largest
     bool operator== (Maze<Mazeable> const &o) const
     {
-        return 
-        wid != o.wid ? false :
-        len != o.len ? false :
-        mz != o.mz ? false : true;
+        if (width() != o.width()) { return false; }
+        if (length() != o.length()) { return false; }
+        for (int i = 0; i < size(); ++i)
+        {
+            if (mz[i].val() != o.mz[i].val()) { return false; }
+        }
+        return true; 
     }
 
     //Inequality op - Compares fields from smallest to largest
@@ -95,6 +98,9 @@ public:
 
     //Accessor for number of rows of cells in the maze (length)
     int length () { return len; }
+    
+    //Const accessor for the number of rows of cells in the maze (length)
+    int length () const { return len; }
 
     /** Element access operator for a maze. Returns a reference to the element
     at position row * maze width + col
@@ -136,6 +142,7 @@ public:
     void connect (int idx1, int idx2)
     {
         if (!hasIndex(idx1) || !hasIndex(idx2)) { return; }
+
         Side src_side = getSide(idx1);
         Side dst_side = getSide(idx2);
         Direction dir = getDirection(idx1, idx2);
@@ -165,6 +172,8 @@ public:
     //Returns true if going in dir from startIdx would remain in maze bounds
     bool validMove (int startIdx, Direction dir)
     {
+        if (!hasIndex(startIdx)) { return false; }
+
         switch(dir)
         {
             case UP:
@@ -172,9 +181,9 @@ public:
             case DOWN:
                 return startIdx + wid < size();
             case LEFT: 
-                return ((startIdx % wid > 0) && hasIndex(startIdx));
+                return startIdx % wid > 0;
             case RIGHT:
-                return (startIdx % wid + 1) < wid;
+                return startIdx % wid + 1 < wid;
             default:
                 break;
         }

--- a/src/include/Wilsons.hpp
+++ b/src/include/Wilsons.hpp
@@ -11,7 +11,7 @@ template<CanMaze Mazeable = std::unique_ptr<Cell[]>>
 class Wilsons
 {
 
-   Maze<Mazeable> &mz; 
+   Maze<Mazeable> mz; 
    std::minstd_rand0 r;
    // TODO: probably make this an int to int map where key is start and val is
    // dst
@@ -44,6 +44,11 @@ public:
       
       if (!open_ends) { mz[0].updateDirection(L_SIDE, LEFT); }
       else { mz.openEnd(); }
+   }
+
+   Maze<Mazeable> release () &&
+   {
+      return std::move(mz);
    }
    
    //ostream operator. Prints the underlying maze

--- a/src/tests/verification.py
+++ b/src/tests/verification.py
@@ -23,6 +23,18 @@ def check_connections(mz: Maze, seed: int, silent: bool = True) -> bool:
         if silent: return False
         good = False
         cell_error(mz.size() - 1, "expected right face to be open (exit of maze)")
+    
+    #make sure bottom left corner's left face isn't open
+    if mz[mz.size() - mz.width() - 1].left:
+        if silent: return False
+        good = False
+        cell_error(mz.size() - mz.width() - 1, "bottom left corner's left face open")
+
+    #make sure top right corner's right face isn't open
+    if mz[mz.width() - 1].right:
+        if silent: return False
+        good = False
+        cell_error(mz.width() - 1, "top right corner's right face open")
 
     cur: Cell
     for idx in range(mz.size()):


### PR DESCRIPTION
In Maze.hpp:
    - validMove now properly checks bounds on attempts to move left and right
    - added a const length accessor
    - fixed operator== (it now does cell by cell comparisons)

In Threading.cpp:
    - removed unnecessary includes
    - halved the size of the raw maze generated for overwrite to reflect the addition of cell packing
    - fixed jthread parallelization (they were not scoped properly)

In mazebuilder.py:
    - the csv flag now creates a file with the proper file name
    - the parallelize function is no longer being called with incorrect length and width parameters

In verification.py:
    - added checks for two cell faces that were previously skipped (the right face of the top right cell and the left face of the bottom left cell)

In HK.hpp and Wilsons.hpp
    - both of these objects now take ownership of the mazes that they are modifying
    - both of these objects now have a release function that moves the maze out of the object